### PR TITLE
Fix issue of deleting read-only files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.8.0</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
On Windows, `FileUtils.forceDelete` at line 30 of `core.SourceCodeManager#checkout` is unable to delete read-only files. Specifically, it cannot delete the files inside .git\objects\pack.

Below is a snapshot of the error.
![image](https://user-images.githubusercontent.com/57175876/194697499-c0612a91-ef24-49e5-a82f-b4ae003b90cf.png)

Updating apache commons io to 2.11.0 fixes this issue.